### PR TITLE
Create missing accounts in config

### DIFF
--- a/src/Faucet/CoinFaucet.ts
+++ b/src/Faucet/CoinFaucet.ts
@@ -26,6 +26,10 @@ export default class CoinFaucet implements Faucet {
     this.amount = config.get(amountConfigAccessor);
   }
 
+  public get address(): string {
+    return this.ethNode.account.address;
+  }
+
   /**
    * Sends value to the given address.
    * @param address The beneficiary.

--- a/src/Faucet/EIP20Faucet.ts
+++ b/src/Faucet/EIP20Faucet.ts
@@ -39,6 +39,10 @@ export default class EIP20Faucet implements Faucet {
     this.amount = config.get(amountConfigAccessor);
   }
 
+  public get address(): string {
+    return this.ethNode.account.address;
+  }
+
   /**
    * Makes an EIP20 transfer to the given address.
    * @param address The beneficiary.

--- a/src/Faucet/Faucet.ts
+++ b/src/Faucet/Faucet.ts
@@ -2,6 +2,11 @@ export default interface Faucet {
   chain: string;
 
   /**
+   * The address of this faucet.
+   */
+  address: string;
+
+  /**
    * Sends value to the given address.
    * @param address The address of the recipient of the value.
    */

--- a/src/Server.ts
+++ b/src/Server.ts
@@ -43,7 +43,10 @@ export default class Server {
     const server = http.createServer(this.requestHandler.bind(this))
 
     return server.listen(this.port, () => {
-      Logger.info(`Server is listening on ${this.port}`)
+      Logger.info(`Server is listening on ${this.port}.`);
+      for (const chain of chains) {
+        Logger.info(`Running faucet ${this.faucets[chain].address} on chain ${chain}.`);
+      }
     })
   }
 
@@ -64,6 +67,13 @@ export default class Server {
         chain,
         interaction,
       );
+
+      if (!account.isInConfig()) {
+        Logger.info(`No Web3 account found for chain ${chain}.`);
+        const newPassword: string = await interaction.inquireNewPassword()
+        account.addNewToConfig(newPassword);
+      }
+
       Logger.info(`Requiring password for account on chain ${chain}`);
       const password = await interaction.inquirePassword();
       account.unlock(password);


### PR DESCRIPTION
The order of execution was wrong. Now, the existance of an account is
checked before it is attempted to be unlocked.

Also improved logging a little bit.

Fixes #4