### PR TITLE
Faucet now responds much faster

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,13 +37,13 @@ If it is `EIP20`, it also requires an `Address`. The `Fund`'s `Amount` is sent p
 `Coin` means it sends base coins.
 `EIP20` means it makes a transaction to the EIP20Token at the given address to `transfer` tokens.
 
-To start, run `npm start -- <chains...>`.
+To start, run `./faucet <chains...>`.
 Chains are identified by their chain id.
-E.g. `npm start -- 3 200`.
+E.g. `./faucet 3 200`.
 For each chain, there must exist a configuration.
 The default configuration is in `./config/default.json`.
 
-Run `npm start -- --help` for help.
+Run `./faucet --help` for help.
 
 Mosaic faucet for base coins and EIP20 tokens.
 

--- a/faucet
+++ b/faucet
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+TS_NODE_FILES=true; TS_NODE_TRANSPILE_ONLY=true; ./node_modules/.bin/ts-node ./src/bin/faucet.ts $@

--- a/package-lock.json
+++ b/package-lock.json
@@ -126,6 +126,11 @@
       "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
       "integrity": "sha1-q8av7tzqUugJzcA3au0845Y10X8="
     },
+    "arg": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.0.tgz",
+      "integrity": "sha512-ZWc51jO3qegGkVh8Hwpv636EkbesNV5ZNQPCtRa+0qytRYPEs9IYT9qITY9buezqUH5uqyzlWLcufrzU2rffdg=="
+    },
     "argparse": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
@@ -1609,6 +1614,11 @@
         "kuler": "1.0.x"
       }
     },
+    "diff": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
+      "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA=="
+    },
     "diffie-hellman": {
       "version": "5.0.3",
       "resolved": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
@@ -2146,8 +2156,8 @@
       "version": "git+https://github.com/ethereumjs/ethereumjs-abi.git#d84a96796079c8595a0c78accd1e7709f2277215",
       "from": "git+https://github.com/ethereumjs/ethereumjs-abi.git",
       "requires": {
-        "bn.js": "^4.10.0",
-        "ethereumjs-util": "^5.0.0"
+        "bn.js": "^4.11.8",
+        "ethereumjs-util": "^6.0.0"
       }
     },
     "ethereumjs-account": {
@@ -3453,6 +3463,11 @@
           "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
         }
       }
+    },
+    "make-error": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.5.tgz",
+      "integrity": "sha512-c3sIjNUow0+8swNwVpqoH4YCShKNFkMaw6oH1mNS2haDZQqkeZFlHS3dhoeEbKKmJB4vXpJucU6oH75aDYeE9g=="
     },
     "md5.js": {
       "version": "1.3.5",
@@ -4968,6 +4983,34 @@
       "resolved": "https://registry.npmjs.org/triple-beam/-/triple-beam-1.3.0.tgz",
       "integrity": "sha512-XrHUvV5HpdLmIj4uVMxHggLbFSZYIn7HEWsqePZcI50pco+MPqJ50wMGY794X7AOOhxOBAjbkqfAbEe/QMp2Lw=="
     },
+    "ts-node": {
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-8.0.3.tgz",
+      "integrity": "sha512-2qayBA4vdtVRuDo11DEFSsD/SFsBXQBRZZhbRGSIkmYmVkWjULn/GGMdG10KVqkaGndljfaTD8dKjWgcejO8YA==",
+      "requires": {
+        "arg": "^4.1.0",
+        "diff": "^3.1.0",
+        "make-error": "^1.1.1",
+        "source-map-support": "^0.5.6",
+        "yn": "^3.0.0"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+        },
+        "source-map-support": {
+          "version": "0.5.11",
+          "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.11.tgz",
+          "integrity": "sha512-//sajEx/fGL3iw6fltKMdPvy8kL3kJ2O3iuYlRoT3k9Kb4BjOoZ+BZzaNHeuaruSt+Kf3Zk9tnfAQg9/AJqUVQ==",
+          "requires": {
+            "buffer-from": "^1.0.0",
+            "source-map": "^0.6.0"
+          }
+        }
+      }
+    },
     "tslib": {
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.3.tgz",
@@ -5623,6 +5666,11 @@
         "buffer-crc32": "~0.2.3",
         "fd-slicer": "~1.1.0"
       }
+    },
+    "yn": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-3.0.0.tgz",
+      "integrity": "sha512-+Wo/p5VRfxUgBUGy2j/6KX2mj9AYJWOHuhMjMcbBFc3y54o9/4buK1ksBvuiK01C3kby8DH9lSmJdSxw+4G/2Q=="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "lint": "eslint src -c .eslintrc.json --ext ts",
-    "start": "ts-node faucet.ts"
+    "start": "ts-node ./src/bin/faucet.ts"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -5,9 +5,7 @@
   "main": "index.js",
   "scripts": {
     "lint": "eslint src -c .eslintrc.json --ext ts",
-    "start": "tsc && node build/faucet.js",
-    "test": "npm run test",
-    "tsc": "tsc"
+    "start": "ts-node faucet.ts"
   },
   "repository": {
     "type": "git",
@@ -24,6 +22,7 @@
     "commander": "^2.19.0",
     "config": "^3.0.1",
     "inquirer": "^6.2.2",
+    "ts-node": "^8.0.3",
     "typescript": "^3.3.3333",
     "web3": "^1.0.0-beta.37",
     "web3-provider-engine": "^14.2.0",

--- a/src/Account.ts
+++ b/src/Account.ts
@@ -12,14 +12,17 @@ export default class Account {
   public chain: string;
   public web3: Web3;
 
-  private interaction: Interaction;
   private accountConfigAccessor: string;
   private web3Account: any;
 
-  constructor(web3: Web3, chain: string, interaction: Interaction) {
+  /**
+   * @param web3 The web3 instance that this account uses.
+   * @param chain 
+   * @param interaction 
+   */
+  constructor(web3: Web3, chain: string) {
     this.web3 = web3;
     this.chain = chain;
-    this.interaction = interaction;
     this.accountConfigAccessor = `Chains.${this.chain}.Account`;
   }
 
@@ -55,18 +58,30 @@ export default class Account {
     Logger.info(`Unlocked account ${this.web3Account.address} on chain ${this.chain}.`);
   }
 
+  /**
+   * The public address of this account.
+   */
   public get address(): string {
     return this.web3Account.address;
   }
 
+  /**
+   * The private key of this account.
+   */
   public get privateKey(): string {
     return this.web3Account.privateKey;
   }
 
+  /**
+   * A function that signs a transaction. As per Web3 account.
+   */
   public get signTransaction(): (tx, callback?) => void {
     return this.web3Account.signTransaction;
   }
 
+  /**
+   * Writes the account into the file that was read by the current config.
+   */
   private updateConfigAccount(encryptedAccount: Object): void {
     const configObject: any = config.util.toObject(config);
     configObject['Chains'][this.chain]['Account'] = encryptedAccount;
@@ -92,6 +107,10 @@ export default class Account {
     process.exit(1);
   }
 
+  /**
+   * Tries to identify which file the config was read from.
+   * @returns The path to the config file. Or an empty string if not found.
+   */
   private getConfigSource(): string {
     const sources = config.util.getConfigSources();
     for (const source of sources) {

--- a/src/Account.ts
+++ b/src/Account.ts
@@ -86,7 +86,9 @@ export default class Account {
     );
 
     // Has to exit as config cannot be reloaded or updated at runtime:
-    Logger.warn('Process has to exit as it does not support dynamic configuration at runtime. Please restart.');
+    Logger.warn(
+      'Process has to exit as it does not support dynamic configuration at runtime. Please restart.'
+    );
     process.exit(1);
   }
 

--- a/src/Faucet/CoinFaucet.ts
+++ b/src/Faucet/CoinFaucet.ts
@@ -34,18 +34,15 @@ export default class CoinFaucet implements Faucet {
    * Sends value to the given address.
    * @param address The beneficiary.
    */
-  public fill(address: string): Promise<string> {
+  public fill(address: string): any {
     Logger.info(`Sending ${this.amount} coins to ${address}.`);
     return this.ethNode.web3.eth.sendTransaction({
       to: address,
       value: this.amount,
       from: this.ethNode.account.address,
-    }).then(
-      (promiEvent) => {
-        const txHash = promiEvent.transactionHash;
-        Logger.info(`Sent ${this.amount} coins to ${address}. TxHash: ${txHash}`);
-
-        return txHash;
-      });
+    }).on(
+      'transactionHash',
+      txHash => Logger.info(`Sent ${this.amount} coins to ${address}. TxHash: ${txHash}`),
+    );
   }
 }

--- a/src/Faucet/CoinFaucet.ts
+++ b/src/Faucet/CoinFaucet.ts
@@ -5,7 +5,7 @@ import Faucet from "./Faucet";
 import Logger from '../Logger';
 
 /**
- * A CoinFaucet sends value in the form of blockchain base coins.
+ * A CoinFaucet sends value in the form of blockchain base coins directly from its address.
  */
 export default class CoinFaucet implements Faucet {
   public ethNode: EthNode;
@@ -13,6 +13,10 @@ export default class CoinFaucet implements Faucet {
 
   private amount: number;
 
+  /**
+   * @param ethNode The EthNode to use as a connection for filling accounts.
+   * @param chain The identifier of the chain that this faucet uses.
+   */
   constructor(ethNode: EthNode, chain: string) {
     this.ethNode = ethNode;
     this.chain = chain;
@@ -26,6 +30,9 @@ export default class CoinFaucet implements Faucet {
     this.amount = config.get(amountConfigAccessor);
   }
 
+  /**
+   * @returns The address of this faucet on the chain.
+   */
   public get address(): string {
     return this.ethNode.account.address;
   }
@@ -33,6 +40,7 @@ export default class CoinFaucet implements Faucet {
   /**
    * Sends value to the given address.
    * @param address The beneficiary.
+   * @returns A Web3 PromiEvent.
    */
   public fill(address: string): any {
     Logger.info(`Sending ${this.amount} coins to ${address}.`);

--- a/src/Faucet/EIP20Faucet.ts
+++ b/src/Faucet/EIP20Faucet.ts
@@ -47,19 +47,15 @@ export default class EIP20Faucet implements Faucet {
    * Makes an EIP20 transfer to the given address.
    * @param address The beneficiary.
    */
-  public fill(address: string): Promise<string> {
+  public fill(address: string): any {
     Logger.info(`Sending ${this.amount} EIP20 tokens to ${address}.`);
     return this.eip20Contract.methods
       .transfer(address, this.amount.toString())
       .send({
         from: this.ethNode.account.address,
-      })
-      .then(
-        (promiEvent) => {
-          const txHash = promiEvent.transactionHash;
-          Logger.info(`Sent ${this.amount} EIP20 tokens to ${address}. TxHash: ${txHash}`);
-
-          return txHash;
-        });
+      }).on(
+        'transactionHash',
+        txHash => Logger.info(`Sent ${this.amount} EIP20 tokens to ${address}. TxHash: ${txHash}`),
+      );
   }
 }

--- a/src/Faucet/EIP20Faucet.ts
+++ b/src/Faucet/EIP20Faucet.ts
@@ -7,7 +7,8 @@ import Logger from '../Logger';
 import * as eip20Abi from '../../abi/EIP20Token.json';
 
 /**
- * An EIP20 faucet sends value in the form of EIP20 tokens.
+ * An EIP20 faucet sends value in the form of EIP20 tokens by sending a transfer transaction to the
+ * EIP20 token.
  */
 export default class EIP20Faucet implements Faucet {
   public ethNode: EthNode;
@@ -17,6 +18,10 @@ export default class EIP20Faucet implements Faucet {
   private amount: number;
   private eip20Contract: any;
 
+  /**
+   * @param ethNode The EthNode to use as a connection for filling accounts.
+   * @param chain The identifier of the chain that this faucet uses.
+   */
   constructor(ethNode: EthNode, chain: string) {
     this.ethNode = ethNode;
     this.chain = chain;
@@ -39,6 +44,9 @@ export default class EIP20Faucet implements Faucet {
     this.amount = config.get(amountConfigAccessor);
   }
 
+  /**
+   * @returns The address of this faucet on the chain.
+   */
   public get address(): string {
     return this.ethNode.account.address;
   }
@@ -46,6 +54,7 @@ export default class EIP20Faucet implements Faucet {
   /**
    * Makes an EIP20 transfer to the given address.
    * @param address The beneficiary.
+   * @returns A Web3 PromiEvent.
    */
   public fill(address: string): any {
     Logger.info(`Sending ${this.amount} EIP20 tokens to ${address}.`);

--- a/src/Faucet/Faucet.ts
+++ b/src/Faucet/Faucet.ts
@@ -9,6 +9,7 @@ export default interface Faucet {
   /**
    * Sends value to the given address.
    * @param address The address of the recipient of the value.
+   * @returns A Web3 PromiEvent.
    */
   fill(address: string): any;
 }

--- a/src/Faucet/Faucet.ts
+++ b/src/Faucet/Faucet.ts
@@ -10,5 +10,5 @@ export default interface Faucet {
    * Sends value to the given address.
    * @param address The address of the recipient of the value.
    */
-  fill(address: string): Promise<string>;
+  fill(address: string): any;
 }

--- a/src/Interaction/CommandLineInteraction.ts
+++ b/src/Interaction/CommandLineInteraction.ts
@@ -6,6 +6,9 @@ import Interaction from "../Interaction";
  * Interaction implementation that requests user input from the command line.
  */
 export default class CommandLineInteraction implements Interaction {
+  /**
+   * Asks the user for a hidden input and returns it.
+   */
   public async inquirePassword(): Promise<string> {
     const input = await inquirer.prompt({
       type: 'password',
@@ -16,6 +19,10 @@ export default class CommandLineInteraction implements Interaction {
     return input.password;
   }
 
+  /**
+   * Asks the user for a hidden password and then again for the same password. Makes sure both
+   * passwords match. Returns the matching password.
+   */
   public async inquireNewPassword(): Promise<string> {
     const firstInput: any = await inquirer.prompt({
       type: 'password',

--- a/src/Server.ts
+++ b/src/Server.ts
@@ -102,7 +102,11 @@ export default class Server {
       if (!stringBody) {
         Logger.info(`Invalid request body: ${stringBody}`);
         response.statusCode = 400;
-        response.end(JSON.stringify({ error: 'Could not read body. You must pass {"beneficiary": "0xaddress@chainId"}' }));
+        response.end(
+          JSON.stringify(
+            { error: 'Could not read body. You must pass {"beneficiary": "0xaddress@chainId"}' }
+          )
+        );
         return;
       }
 
@@ -111,7 +115,11 @@ export default class Server {
       if (!address || !chain) {
         Logger.info(`Invalid request body: ${stringBody}`);
         response.statusCode = 400;
-        response.end(JSON.stringify({ error: 'Could not read body. You must pass {"beneficiary": "0xaddress@chainId"}' }));
+        response.end(
+          JSON.stringify(
+            { error: 'Could not read body. You must pass {"beneficiary": "0xaddress@chainId"}' }
+          )
+        );
         return;
       }
 
@@ -129,12 +137,20 @@ export default class Server {
           .catch((error) => {
             Logger.error(`Could not fill address from faucet ${faucet.chain}: ${error.toString()}`);
             response.statusCode = 500;
-            response.end(JSON.stringify({ error: 'Could not fill address', details: error.toString() }));
+            response.end(
+              JSON.stringify(
+                { error: 'Could not fill address', details: error.toString() }
+              )
+            );
           });
       } catch (error) {
         Logger.error(`Could not fill address from faucet ${faucet.chain}: ${error.toString()}`);
         response.statusCode = 500;
-        response.end(JSON.stringify({ error: 'Could not fill address', details: error.toString() }));
+        response.end(
+          JSON.stringify(
+            { error: 'Could not fill address', details: error.toString() }
+          )
+        );
         return;
       }
     });

--- a/src/Server.ts
+++ b/src/Server.ts
@@ -133,16 +133,22 @@ export default class Server {
 
       try {
         faucet.fill(address)
-          .then(txHash => response.end(JSON.stringify({ txHash })))
-          .catch((error) => {
-            Logger.error(`Could not fill address from faucet ${faucet.chain}: ${error.toString()}`);
-            response.statusCode = 500;
-            response.end(
-              JSON.stringify(
-                { error: 'Could not fill address', details: error.toString() }
-              )
-            );
-          });
+          .on(
+            'transactionHash',
+            txHash => response.end(JSON.stringify({ txHash })),
+          )
+          .on(
+            'error',
+            (error) => {
+              Logger.error(`Could not fill address from faucet ${faucet.chain}: ${error.toString()}`);
+              response.statusCode = 500;
+              response.end(
+                JSON.stringify(
+                  { error: 'Could not fill address', details: error.toString() }
+                )
+              );
+            }
+          );
       } catch (error) {
         Logger.error(`Could not fill address from faucet ${faucet.chain}: ${error.toString()}`);
         response.statusCode = 500;

--- a/src/Server.ts
+++ b/src/Server.ts
@@ -65,7 +65,6 @@ export default class Server {
       const account: Account = new Account(
         web3,
         chain,
-        interaction,
       );
 
       if (!account.isInConfig()) {

--- a/src/bin/faucet.ts
+++ b/src/bin/faucet.ts
@@ -4,9 +4,9 @@
 
 import * as faucet from 'commander';
 
-import Server from './src/Server';
+import Server from '../Server';
 
-import { version } from './package.json';
+import { version } from '../../package.json';
 
 
 faucet

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,6 @@
     "compilerOptions": {
         "target": "es6",
         "module": "commonjs",
-        "outDir": "build",
         "sourceMap": true,
         "types": [
             "node"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,7 +9,6 @@
         "resolveJsonModule": true
     },
     "include": [
-        "faucet.ts",
         "src/**/*.ts"
     ],
     "exclude": [


### PR DESCRIPTION
The faucet now uses the events from the Web3 `PromiEvent` instead of waiting for the `PromiEvent` promise to resolve.

As the transaction hash is available immediately after submitting the transaction, the faucet now responds *much* faster.

Most important changes (faucets' `fill` methods and `Server` handling the response):

* https://github.com/OpenST/faucet/pull/11/files#diff-0ddd07058acfbeb8e69e189e496b55acR51
* https://github.com/OpenST/faucet/pull/11/files#diff-b00fea40ecadd6d1da036a18ae50f799R65
* https://github.com/OpenST/faucet/pull/11/files#diff-6c2457f8d2ec445121180785c06fec52R135

Also improved project setup, documentation, and styling.

The faucet can now be run with `./faucet 3 200` (for example).

Fixes #6 