### PR TITLE
Environment variables support for account passwords

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Use the `--port` option to run the faucet at a different port than the default o
 Use the `--non-interactive` option to run the faucet non-interactively. 
 You must export ENV variables in below format
 ```
-export ACCOUNT_ADDRESS_PASSW_{chainid}={account_password}
+export ENV_ACCOUNT_PASSW_{chainid}={account_password}
 ``` 
 Example:
 ```

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # 🚰 Mosaic Faucet
 
-Mosaic Faucet is a ethereum faucet that supports multiple chains simultaneously.
+Mosaic Faucet is an ethereum faucet that supports multiple chains simultaneously.
 
 ## Using an Existing Faucet
 
@@ -46,8 +46,15 @@ The default configuration is in `./config/default.json`.
 Use the `--port` option to run the faucet at a different port than the default one.
 `./faucet --port 8080 1407`
 
-Use the `--non-interactive` option to run the faucet non-interactively. You must provide a path to a password file. The file must contain one password per line, in the order that you start name the chains in the command. In the following example, `./password.txt` has to have two lines, with the password for chain `1406` on the first line.
-`./faucet --non-interactive ./password.txt 1406 1407`
+Use the `--non-interactive` option to run the faucet non-interactively. 
+You must export ENV variables in below format
+```
+export ACCOUNT_ADDRESS_PASSW_{chainid}={account_password}
+``` 
+Example:
+```
+./faucet --non-interactive 1406 1407
+```
 
 Run `./faucet --help` for more help.
 

--- a/config/default.json.dist
+++ b/config/default.json.dist
@@ -13,7 +13,7 @@
       "WebSocket": "ws://localhost:8548",
       "Funds": {
         "Type": "Coin",
-        "Amount": 10
+        "Amount": 10,
         "BalanceThreshold": "100"
       }
     }

--- a/src/Interaction/NonInteractiveInteraction.ts
+++ b/src/Interaction/NonInteractiveInteraction.ts
@@ -1,5 +1,3 @@
-import fs from 'fs';
-
 import Interaction from '../Interaction';
 import Logger from "../Logger";
 const ENV_ACCOUNT_PASSWORD_PREFIX = 'ENV_ACCOUNT_PASSW_';

--- a/src/Interaction/NonInteractiveInteraction.ts
+++ b/src/Interaction/NonInteractiveInteraction.ts
@@ -1,6 +1,7 @@
 import fs from 'fs';
 
 import Interaction from '../Interaction';
+import Logger from "../Logger";
 const ENV_ACCOUNT_PASSWORD_PREFIX = 'ENV_ACCOUNT_PASSW_';
 
 /** A map of chain Ids to their respective password. */
@@ -26,9 +27,10 @@ export default class NonInteractiveInteraction implements Interaction {
       const chain = chains[index];
       const account_password = process.env[`${ENV_ACCOUNT_PASSWORD_PREFIX}${chain}`];
       // Assigns the password to the chain on the field.
-      if (account_password) {
-        this.passwords[chain] = account_password;
+      if (!account_password) {
+        Logger.error(`Password missing for chain: ${chain}`);
       }
+      this.passwords[chain] = account_password;
     }
     if (Object.keys(this.passwords).length !== chains.length) {
       throw new Error('Number of exported passwords does not match number of chains.');

--- a/src/Interaction/NonInteractiveInteraction.ts
+++ b/src/Interaction/NonInteractiveInteraction.ts
@@ -1,7 +1,7 @@
 import fs from 'fs';
 
 import Interaction from '../Interaction';
-const ENV_ACCOUNT_PASSWORD_PREFIX = 'ACCOUNT_ADDRESS_PASSW_';
+const ENV_ACCOUNT_PASSWORD_PREFIX = 'ENV_ACCOUNT_PASSW_';
 
 /** A map of chain Ids to their respective password. */
 interface Passwords {
@@ -26,7 +26,7 @@ export default class NonInteractiveInteraction implements Interaction {
       const chain = chains[index];
       const account_password = process.env[`${ENV_ACCOUNT_PASSWORD_PREFIX}${chain}`];
       // Assigns the password to the chain on the field.
-      if (!account_password) {
+      if (account_password) {
         this.passwords[chain] = account_password;
       }
     }

--- a/src/Interaction/NonInteractiveInteraction.ts
+++ b/src/Interaction/NonInteractiveInteraction.ts
@@ -1,6 +1,7 @@
 import fs from 'fs';
 
 import Interaction from '../Interaction';
+const ENV_ACCOUNT_PASSWORD_PREFIX = 'ACCOUNT_ADDRESS_PASSW_';
 
 /** A map of chain Ids to their respective password. */
 interface Passwords {
@@ -19,17 +20,18 @@ export default class NonInteractiveInteraction implements Interaction {
    * of chains. The passwords will be associated to the chains in the same order. The first chain
    * in the array will get the first pasword from the password file and so on.
    * @param chains The chains identifiers in an array.
-   * @param passwordPath The path to the password file.
    */
-  public constructor(chains: string[], passwordPath: string) {
-    const passwords: string[] = NonInteractiveInteraction.readPasswords(passwordPath);
-    if (passwords.length !== chains.length) {
-      throw new Error('Number of passwords in file does not match number of chains.');
-    }
-
-    for (let index = 0; index < passwords.length; index += 1) {
+  public constructor(chains: string[]) {
+    for (let index = 0; index < chains.length; index += 1) {
+      const chain = chains[index];
+      const account_password = process.env[`${ENV_ACCOUNT_PASSWORD_PREFIX}${chain}`];
       // Assigns the password to the chain on the field.
-      this.passwords[chains[index]] = passwords[index];
+      if (!account_password) {
+        this.passwords[chain] = account_password;
+      }
+    }
+    if (Object.keys(this.passwords).length !== chains.length) {
+      throw new Error('Number of exported passwords does not match number of chains.');
     }
   }
 
@@ -48,14 +50,5 @@ export default class NonInteractiveInteraction implements Interaction {
    */
   public async inquireNewPassword(): Promise<string> {
     throw new Error('Cannot inquire new passwords non-interactively.');
-  }
-
-  private static readPasswords(path: string): string[] {
-    const passwordFile: string = fs.readFileSync(path, 'utf8');
-
-    const passwords = passwordFile.split('\n');
-
-    // Remove last empty element due to last line break:
-    return passwords.filter((password: string): boolean => password.length > 0);
   }
 }

--- a/src/bin/faucet.ts
+++ b/src/bin/faucet.ts
@@ -16,7 +16,7 @@ faucet
   .description('Mosaic faucet for base coins and EIP20 tokens.')
   .arguments('<chains...>')
   .option('-p, --port <port>', 'the port where the server listens on', parseInt)
-  .option('-n, --non-interactive <path>', 'run the faucet non-interactively')
+  .option('-n, --non-interactive', 'run the faucet non-interactively')
   .action(
     async (chains: string[], command): Promise<void> => {
       const port = command.port === undefined ? DEFAULT_PORT : command.port;
@@ -26,7 +26,7 @@ faucet
         interaction = new CommandLineInteraction();
       } else {
         try {
-          interaction = new NonInteractiveInteraction(chains, command.nonInteractive);
+          interaction = new NonInteractiveInteraction(chains);
         } catch (error) {
           Logger.error(error.toString());
           process.exit(1);


### PR DESCRIPTION
Currently to run faucets for multiple chains, multiple passwords are kept in a password file. The password file has no knowledge of chain account password belongs to.
This becomes problematic for devops for maintaining password files.

Proposal is to support environment variables in below format.
```
export ACCOUNT_PASSWORD_{chainid}={account_password}
```
 
 Fixes #25 